### PR TITLE
Initialize turborepo scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Platforms
+# fe-infra-platform

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "web",
+  "private": true
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "docs",
+  "private": true
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fe-infra-platform",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "docs"
+  ]
+}
+

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "config",
+  "private": true
+}

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "dev-tools",
+  "private": true
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- scaffold a new Turborepo monorepo named **fe-infra-platform**
- configure Yarn workspaces for apps, packages, and docs
- define basic Turbo build, lint, and dev pipelines

## Testing
- `git log --oneline -2`

------
https://chatgpt.com/codex/tasks/task_e_68499e76fdb08321ac442719168f09d5