### PR TITLE
Add shared config workspace and lint setup

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, sourcing..."
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../packages/config/.eslintrc.js'],
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../packages/config/.eslintrc.js'],
+};

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,25 @@
     "apps/*",
     "packages/*",
     "docs"
-  ]
+  ],
+  "scripts": {
+    "lint": "turbo run lint",
+    "format": "turbo run format",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^8.0.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^13.0.0",
+    "prettier": "^2.8.0",
+    "typescript": "^5.0.0"
+  },
+  "lint-staged": {
+    "*.ts?(x)": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
 }
-

--- a/packages/config/.eslintrc.js
+++ b/packages/config/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+};

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,4 +1,5 @@
 {
-  "name": "config",
+  "name": "@org/config",
+  "version": "1.0.0",
   "private": true
 }

--- a/packages/config/prettier.config.js
+++ b/packages/config/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  semi: true,
+  printWidth: 80,
+};

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "baseUrl": "../..",
+    "paths": {
+      "@org/*": ["packages/*/src"]
+    }
+  }
+}

--- a/packages/dev-tools/.eslintrc.js
+++ b/packages/dev-tools/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../config/.eslintrc.js'],
+};

--- a/packages/dev-tools/tsconfig.json
+++ b/packages/dev-tools/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
## Summary
- add `packages/config` with ESLint, Prettier and TypeScript base configs
- set up Husky pre-commit hook with lint‑staged
- reference shared configs from all workspaces

## Testing
- `npx husky install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68499f60c7408321ac89736f9d46fc53